### PR TITLE
fix: Correct the spelling of 'referer' in the request headers

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -29,7 +29,7 @@ export async function fileMoreApi({
     body,
     headers: {
       origin: urlInstance.origin,
-      referrer: shareUrl,
+      referer: shareUrl,
     },
   });
   const json: {


### PR DESCRIPTION
referer拼错了，改正后不会报错400，能正常302到直链

![](https://github.com/user-attachments/assets/439e43a1-036f-4041-938f-2eda38e4386f)
